### PR TITLE
Update Packer code for Ubuntu 22.04 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Code examples from my blog covering Packer, Ansible, Vagrant and VirtualBox. See
 
 The code in this repository allows you to create a local Vagrant base box meeting [the requirements](https://www.vagrantup.com/docs/boxes/base) documented by HashiCorp as conveniently as possible. Although I tried to be quite generic in the way the code is written, I wrote it for myself and, nor won't guarantee it works for you. Please refer to the [License](LICENSE) for details.
 
-For each Packer build I implemented you'll find a `prepare-*.sh` script prompting you for input before creating the Packer JSON file. Each build contains a set of templates in the `template` folder. Placeholders in the templates will be substituted with your answers. Once that's completed, a build file will be present in the top level directory for you to run.
+For each Packer build I implemented you'll find a `prepare-*.sh` script prompting you for input before creating the Packer JSON file. Each build contains a set of templates in the `template` folder. Placeholders in the templates will be substituted with your answers. Once that's completed, a build file will be present in the top level directory for you to run. Make sure you check the auto-generated file for correctness. As I said before, this file works for what I need it to do, your directory structure is most likely different.
 
 It is assumed you verified the installation media, most notably the SHA256 checksums.
 
@@ -32,8 +32,10 @@ The process of creating Vagrant base boxes is documented on my blog.
 
 ## Notes
 
-This repository's code was developed on Ubuntu 20.04 LTS using
+This repository's code was developed on Ubuntu 22.04 LTS using the standard package sources for Ansible. Packer and VirtualBox have been downloaded an installed from the Web.
 
-- Ansible 2.9
-- Packer 1.7
-- VirtualBox 6.1.26
+> Before installing software always make sure you read, understand and abide by the license agreement!
+
+- Ansible 2.10.8
+- Packer 1.8.4
+- VirtualBox 6.1.40

--- a/ansible/vagrant-OracleLinux-7-guest-additions.yml
+++ b/ansible/vagrant-OracleLinux-7-guest-additions.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Martin Bach
+# Copyright 2022 Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible/vagrant-OracleLinux-8-guest-additions.yml
+++ b/ansible/vagrant-OracleLinux-8-guest-additions.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Martin Bach
+# Copyright 2022 Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible/vagrant-debian-11-guest-additions.yml
+++ b/ansible/vagrant-debian-11-guest-additions.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Martin Bach
+# Copyright 2022 Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/prepare-OracleLinux-7.sh
+++ b/prepare-OracleLinux-7.sh
@@ -9,7 +9,7 @@
 # Version History
 # 20210823 initial version
 #
-# Copyright 2021 Martin Bach
+# Copyright 2022 Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/prepare-OracleLinux-8.sh
+++ b/prepare-OracleLinux-8.sh
@@ -3,13 +3,13 @@
 # prepare-OracleLinux-8.sh
 # ---------------------------------------------------------------------------
 # A short script to set up packer for building an Oracle Linux 8 system
-#
-# Tested and written on Ubuntu 20.04 LTS
+# Refer to the readme file for details
 #
 # Version History
 # 20210823 initial version
+# 20221031 update for Oracle Linux 8.5/Packer 1.8.x/Ansible 2.10.x
 #
-# Copyright 2021 Martin Bach
+# Copyright 2022 Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,8 +59,8 @@ echo "INFO: kickstart file ready"
 echo
 # -------------------------- step 2: create the packer build instructions
 
-DEFAULT_INSTALL_ISO="/m/stage/V1009565-01-ol8.4.iso"
-DEFAULT_BOX_LOC="${HOME}/vagrant/boxes/ol8_8.4.2.box"
+DEFAULT_INSTALL_ISO="/m/iso/V1018317-01-OL8.5.iso"
+DEFAULT_BOX_LOC="${HOME}/vagrant/boxes/ol8_8.5.0.box"
 
 read -p "Enter the location of the Oracle Linux 8 installation media (${DEFAULT_INSTALL_ISO})": INSTALL_ISO
 if [ ! -f ${INSTALL_ISO:=${DEFAULT_INSTALL_ISO}} ]; then

--- a/prepare-debian11.sh
+++ b/prepare-debian11.sh
@@ -8,8 +8,9 @@
 #
 # Version History
 # 20210823 initial version
+# 20221031 maintenance updates
 #
-# Copyright 2021 Martin Bach
+# Copyright 2022 Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -61,8 +62,8 @@ template/preseed-debian-11-template.cfg > http/preseed.cfg
 
 # -------------------------- step 2: create the packer build instructions
 
-DEFAULT_NETINST_ISO="/m/stage/debian-11.0.0-amd64-netinst.iso"
-DEFAULT_BOX_LOC="${HOME}/vagrant/boxes/debian-11-01.box"
+DEFAULT_NETINST_ISO="/m/iso/debian-11.5.0-amd64-netinst.iso"
+DEFAULT_BOX_LOC="${HOME}/vagrant/boxes/debian-11.5.0.box"
 
 read -p "Enter the location of the Debian 11 network installation media (${DEFAULT_NETINST_ISO})": NETINST_ISO
 if [ ! -f ${NETINST_ISO:=${DEFAULT_NETINST_ISO}} ]; then

--- a/template/kickstart-OracleLinux-7-template.ks
+++ b/template/kickstart-OracleLinux-7-template.ks
@@ -2,7 +2,7 @@
 
 # Simple kickstart file for Oracle Linux 7.x to create the most basic Vagrant base box
 #
-# Copyright 2021 Martin Bach
+# Copyright 2022 Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/template/kickstart-OracleLinux-8-template.ks
+++ b/template/kickstart-OracleLinux-8-template.ks
@@ -2,7 +2,7 @@
 
 # Simple kickstart file for Oracle Linux 8.x to create the most basic Vagrant base box
 #
-# Copyright 2021 Martin Bach
+# Copyright 2022 Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/template/preseed-debian-11-template.cfg
+++ b/template/preseed-debian-11-template.cfg
@@ -1,6 +1,6 @@
 #_preseed_V1
 
-# Copyright 2021 Martin Bach
+# Copyright 2022 Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
After an update to Ubuntu 22.04 LTS a code refresh has become necessary. Both Debian 11 and Oracle 8 have been tested with Oracle Linux 7 left as it was (under the assumption that it will still work with 7.9 as before).

The tests have been performed with Ubuntu 22.04 LTS on x86-64 and the following components:
- VirtualBox 6.1.40 (downloaded from the official website)
- Packer 1.8.4 (downloaded from the official website)
- Ansible 2.10.8 (as per the distribution)